### PR TITLE
feat: add gitlab role and playbook

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ploigos
 name: service_configs
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.6
+version: 1.0.7
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -17,6 +17,7 @@ readme: README.md
 # @nicks:irc/im.site#channel'
 authors:
 - Andy Krohg <akrohg@redhat.com>
+- Jennifer Power <jpower@redhat.com>
 
 
 ### OPTIONAL but strongly recommended

--- a/playbooks/gitlab.yml
+++ b/playbooks/gitlab.yml
@@ -3,8 +3,7 @@
   - role: gitlab
     vars:
       gitlab_url: "{{ all_services_details.gitlab.url }}"
-      gitab_username: "{{ all_services_details.gitlab.username }}"
-      gitlab_password: "{{ all_services_details.gitlab.password }}"
+      gitlab_root_token: "{{ all_services_details.gitlab.api_token }}"
 
       ploigos_service_account:
         first_name: Ploigos

--- a/playbooks/gitlab.yml
+++ b/playbooks/gitlab.yml
@@ -1,0 +1,14 @@
+- hosts: localhost
+  roles:
+  - role: gitlab
+    vars:
+      gitlab_url: "{{ all_services_details.gitlab.url }}"
+      gitab_username: "{{ all_services_details.gitlab.username }}"
+      gitlab_password: "{{ all_services_details.gitlab.password }}"
+
+      ploigos_service_account:
+        first_name: Ploigos
+        last_name: ServiceAccount
+        username: ploigos
+        password: password123
+        email: ploigos@example.com

--- a/roles/gitlab/defaults/main.yml
+++ b/roles/gitlab/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 gitlab_url: "{{ all_services_details.gitlab.url }}"
-gitlab_username: "{{ all_services_details.gitlab.username }}"
-gitlab_password: "{{ all_services_details.gitlab.password }}"
+gitlab_root_token: "{{ all_services_details.gitlab.api_token }}"
 
 oc_cli: /usr/local/bin/oc
 

--- a/roles/gitlab/defaults/main.yml
+++ b/roles/gitlab/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+gitlab_url: "{{ all_services_details.gitlab.url }}"
+gitlab_username: "{{ all_services_details.gitlab.username }}"
+gitlab_password: "{{ all_services_details.gitlab.password }}"
+
+oc_cli: /usr/local/bin/oc
+
+ploigos_service_account:
+  first_name: Ploigos
+  last_name: ServiceAccount
+  username: ploigos
+  password: password123
+  email: ploigos@example.com

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -8,38 +8,6 @@
   retries: 30
   delay: 5
 
-- name: Generate root token
-  set_fact:
-    gitlab_root_token: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"
-
-- name: Set api creation command
-  set_fact:
-    gitlab_console_command: >-
-      "token = User.find_by_username('root').personal_access_tokens.create(scopes: [:api, :read_api, :sudo, :read_user],name: 'Automation token');
-      token.set_token('{{ gitlab_root_token }}'); token.save!"
-
-- name: Create access token for GitLab root user
-  shell: |
-    oc='{{ oc_cli }}'
-    set -eo pipefail
-    pod=$($oc get pods -n gitlab-system -l app=task-runner -o jsonpath='{.items[0].metadata.name}')
-    output=$($oc exec $pod -n gitlab-system -c task-runner -- gitlab-rails runner {{ gitlab_console_command }} 2>&1 >/dev/null)
-    if [ ! -z "$output" ]; then
-      if echo "$output" | grep -q 'already exist'; then
-          echo ok
-      else
-          echo failed
-      fi
-    else
-      echo changed
-    fi
-    echo $output
-  register: gitlab_token
-  args:
-    executable: /bin/bash
-  failed_when: '"failed" in gitlab_token.stdout_lines'
-  changed_when: '"changed" in gitlab_token.stdout_lines'
-
 - name: Check for existing Service Account for GitLab
   uri:
     url: '{{ gitlab_url }}/api/v4/users?username={{ ploigos_service_account.username }}'
@@ -147,11 +115,3 @@
       register: response
       changed_when: response.status == 201
   when: gitlab_access_token_response.json == []
-
-- name: Revoke access token for GitLab root user
-  shell: |
-    oc='{{ oc_cli }}'
-    pod=$($oc get pods -n gitlab-system -l app=task-runner -o jsonpath='{.items[0].metadata.name}')
-    $oc exec $pod -n gitlab-system -c task-runner -- gitlab-rails runner "token = PersonalAccessToken.find_by_token('{{ gitlab_root_token }}');token.revoke!"
-  register: gitlab_revoke_token
-  changed_when: gitlab_token.stdout_lines == []

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -112,6 +112,34 @@
           path: "Red_Hat"
           visibility: "public"
         status_code: 201,422
-      register: response
-      changed_when: response.status == 201
+      register: group_creation_response
+      changed_when: group_creation_response.status == 201
+
+    - name: Get group information
+      uri:
+        url: '{{ gitlab_url }}/api/v4/groups/{{ group_creation_response.json.id }}'
+        validate_certs: false
+        body_format: json
+        method: Get
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_access_token }}"
+        status_code: 200
+      register: group_check_response
+
+    - name: Grab token from response
+      set_fact:
+        gitlab_runner_token: '{{ group_check_response.json.runners_token }}'
+
+    - name: Store GitLab runner token
+      block:
+      # Create a Secret to hold the GitLab Access Token if this role is run by
+      # the operator.
+        - name: Create GitLab token secret
+          k8s:
+            definition: "{{ lookup('template', 'gitlab-runner-token-secret.yml.j2') }}"
+      rescue:
+        - name: Print access token to stdout
+          debug:
+            msg: |
+              GitLab RUNNER TOKEN: {{ gitlab_runner_token }}
   when: gitlab_access_token_response.json == []

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -1,0 +1,154 @@
+
+
+- name: Wait for GitLab to respond to requests
+  uri:
+    url: '{{ gitlab_url }}'
+    validate_certs: no
+  register: _gitlab_endpoint
+  until: _gitlab_endpoint.status == 200
+  retries: 30
+  delay: 5
+
+- name: Generate root token
+  set_fact:
+    gitlab_root_token: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"
+
+- name: Set api creation command
+  set_fact:
+    gitlab_console_command: >-
+      "token = User.find_by_username('root').personal_access_tokens.create(scopes: [:api, :read_api, :sudo, :read_user],name: 'Automation token'); token.set_token('{{ gitlab_root_token }}'); token.save!"
+
+- name: Create access token for GitLab root user
+  shell: |
+    oc='{{ oc_cli }}'
+    pod=$($oc get pods -n gitlab-system -l app=task-runner -o jsonpath='{.items[0].metadata.name}')
+    output=$($oc exec $pod -n gitlab-system -c task-runner -- gitlab-rails runner {{ gitlab_console_command }} 2>&1 >/dev/null)
+    if [ ! -z "$output" ]; then
+      if echo "$output" | grep -q 'already exist'; then
+          echo ok
+      else
+          echo failed
+      fi
+    else
+      echo changed
+    fi
+    echo $output
+  register: gitlab_token
+  failed_when: '"failed" in gitlab_token.stdout_lines'
+  changed_when: '"changed" in gitlab_token.stdout_lines'
+
+- name: Check for existing Service Account for GitLab
+  uri:
+    url: '{{ gitlab_url }}/api/v4/users?username={{ ploigos_service_account.username }}'
+    validate_certs: no
+    method: GET
+    return_content: yes
+    body_format: json
+    headers:
+      PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+    status_code: 200
+  register: gitlab_user_check_response
+
+- name: Set GitLab User info
+  set_fact:
+      gitlab_user_info: "{{ gitlab_user_check_response.json[0] }}"
+  when: gitlab_user_check_response.json != []
+
+- name: Create GitLab Service Account if it doesn't exist
+  block:
+    - name: Create Service Account for GitLab
+      uri:
+        url: '{{ gitlab_url }}/api/v4/users'
+        validate_certs: no
+        body_format: json
+        method: POST
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+        body:
+          email: '{{ ploigos_service_account.email }}'
+          name: "{{ ploigos_service_account.first_name + ' ' + ploigos_service_account.last_name }}"
+          reset_password: false
+          password: '{{ ploigos_service_account.password }}'
+          username: '{{ ploigos_service_account.username }}'
+          skip_confirmation: true
+        status_code: 201,422
+      register: gitlab_user_response
+      changed_when: gitlab_user_response.status == 201
+
+    - name: Set GitLab User info
+      set_fact:
+        gitlab_user_info: "{{ gitlab_user_response.json }}"
+  when: gitlab_user_check_response.json == []
+
+- name: Check Service Account token is present
+  uri:
+    url: '{{ gitlab_url }}/api/v4/personal_access_tokens?user_id={{ gitlab_user_info.id }}'
+    validate_certs: no
+    method: GET
+    return_content: yes
+    body_format: json
+    headers:
+      PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+    status_code: 200
+  register: gitlab_access_token_response
+
+- name: Create GitLab access token if it doesn't exist
+  block:
+    - name: Create Application Token for GitLab
+      uri:
+        url: '{{gitlab_url}}/api/v4/users/{{ gitlab_user_info.id }}/personal_access_tokens'
+        validate_certs: no
+        body_format: json
+        method: POST
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_root_token }}"
+        body:
+          name: ploigos-platform-token
+          scopes: [api, read_user, read_api, read_repository, write_repository]
+        status_code: 201,422
+      register: token_creation_response
+      changed_when: token_creation_response.status == 201
+
+    - name: Grab token from response
+      set_fact:
+        gitlab_access_token: '{{ token_creation_response.json.token }}'
+
+    - name: Store GitLab access token
+      block:
+      # Create a Secret to hold the GitLab Access Token if this role is run by
+      # the operator.
+      - name: Create GitLab token secret
+        k8s:
+          definition: "{{ lookup('template', 'gitlab-token-secret.yml.j2') }}"
+      rescue:
+      - name: Print access token to stdout
+        debug:
+          msg: |
+            GitLab ACCESS TOKEN: {{ gitlab_access_token }}
+      
+
+    - name: Create Group for Service Account
+      uri:
+        url: '{{ gitlab_url }}/api/v4/groups'
+        validate_certs: no
+        body_format: json
+        method: POST
+        headers:
+          PRIVATE-TOKEN: "{{ gitlab_access_token }}"
+          Content-Type: "application/json"
+        body:
+          description: "Ploiogos Platform Organization"
+          name: "platform"
+          path: "Red_Hat"
+          visibility: "public"
+        status_code: 201,422
+      register: response
+      changed_when: response.status == 201
+  when: gitlab_access_token_response.json == []
+
+- name: Revoke access token for root user
+  shell: |
+    oc='{{ oc_cli }}'
+    pod=$($oc get pods -n gitlab-system -l app=task-runner -o jsonpath='{.items[0].metadata.name}')
+    $oc exec $pod -n gitlab-system -c task-runner -- gitlab-rails runner "token = PersonalAccessToken.find_by_token('{{ gitlab_root_token }}');token.revoke!"
+ 

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -1,9 +1,8 @@
-
-
+---
 - name: Wait for GitLab to respond to requests
   uri:
     url: '{{ gitlab_url }}'
-    validate_certs: no
+    validate_certs: false
   register: _gitlab_endpoint
   until: _gitlab_endpoint.status == 200
   retries: 30
@@ -16,11 +15,13 @@
 - name: Set api creation command
   set_fact:
     gitlab_console_command: >-
-      "token = User.find_by_username('root').personal_access_tokens.create(scopes: [:api, :read_api, :sudo, :read_user],name: 'Automation token'); token.set_token('{{ gitlab_root_token }}'); token.save!"
+      "token = User.find_by_username('root').personal_access_tokens.create(scopes: [:api, :read_api, :sudo, :read_user],name: 'Automation token');
+      token.set_token('{{ gitlab_root_token }}'); token.save!"
 
 - name: Create access token for GitLab root user
   shell: |
     oc='{{ oc_cli }}'
+    set -eo pipefail
     pod=$($oc get pods -n gitlab-system -l app=task-runner -o jsonpath='{.items[0].metadata.name}')
     output=$($oc exec $pod -n gitlab-system -c task-runner -- gitlab-rails runner {{ gitlab_console_command }} 2>&1 >/dev/null)
     if [ ! -z "$output" ]; then
@@ -34,15 +35,17 @@
     fi
     echo $output
   register: gitlab_token
+  args:
+    executable: /bin/bash
   failed_when: '"failed" in gitlab_token.stdout_lines'
   changed_when: '"changed" in gitlab_token.stdout_lines'
 
 - name: Check for existing Service Account for GitLab
   uri:
     url: '{{ gitlab_url }}/api/v4/users?username={{ ploigos_service_account.username }}'
-    validate_certs: no
+    validate_certs: false
     method: GET
-    return_content: yes
+    return_content: true
     body_format: json
     headers:
       PRIVATE-TOKEN: "{{ gitlab_root_token }}"
@@ -51,7 +54,7 @@
 
 - name: Set GitLab User info
   set_fact:
-      gitlab_user_info: "{{ gitlab_user_check_response.json[0] }}"
+    gitlab_user_info: "{{ gitlab_user_check_response.json[0] }}"
   when: gitlab_user_check_response.json != []
 
 - name: Create GitLab Service Account if it doesn't exist
@@ -59,7 +62,7 @@
     - name: Create Service Account for GitLab
       uri:
         url: '{{ gitlab_url }}/api/v4/users'
-        validate_certs: no
+        validate_certs: false
         body_format: json
         method: POST
         headers:
@@ -83,9 +86,9 @@
 - name: Check Service Account token is present
   uri:
     url: '{{ gitlab_url }}/api/v4/personal_access_tokens?user_id={{ gitlab_user_info.id }}'
-    validate_certs: no
+    validate_certs: false
     method: GET
-    return_content: yes
+    return_content: true
     body_format: json
     headers:
       PRIVATE-TOKEN: "{{ gitlab_root_token }}"
@@ -96,8 +99,8 @@
   block:
     - name: Create Application Token for GitLab
       uri:
-        url: '{{gitlab_url}}/api/v4/users/{{ gitlab_user_info.id }}/personal_access_tokens'
-        validate_certs: no
+        url: '{{ gitlab_url }}/api/v4/users/{{ gitlab_user_info.id }}/personal_access_tokens'
+        validate_certs: false
         body_format: json
         method: POST
         headers:
@@ -117,20 +120,19 @@
       block:
       # Create a Secret to hold the GitLab Access Token if this role is run by
       # the operator.
-      - name: Create GitLab token secret
-        k8s:
-          definition: "{{ lookup('template', 'gitlab-token-secret.yml.j2') }}"
+        - name: Create GitLab token secret
+          k8s:
+            definition: "{{ lookup('template', 'gitlab-token-secret.yml.j2') }}"
       rescue:
-      - name: Print access token to stdout
-        debug:
-          msg: |
-            GitLab ACCESS TOKEN: {{ gitlab_access_token }}
-      
+        - name: Print access token to stdout
+          debug:
+            msg: |
+              GitLab ACCESS TOKEN: {{ gitlab_access_token }}
 
     - name: Create Group for Service Account
       uri:
         url: '{{ gitlab_url }}/api/v4/groups'
-        validate_certs: no
+        validate_certs: false
         body_format: json
         method: POST
         headers:
@@ -146,9 +148,10 @@
       changed_when: response.status == 201
   when: gitlab_access_token_response.json == []
 
-- name: Revoke access token for root user
+- name: Revoke access token for GitLab root user
   shell: |
     oc='{{ oc_cli }}'
     pod=$($oc get pods -n gitlab-system -l app=task-runner -o jsonpath='{.items[0].metadata.name}')
     $oc exec $pod -n gitlab-system -c task-runner -- gitlab-rails runner "token = PersonalAccessToken.find_by_token('{{ gitlab_root_token }}');token.revoke!"
- 
+  register: gitlab_revoke_token
+  changed_when: gitlab_token.stdout_lines == []

--- a/roles/gitlab/templates/gitlab-runner-token-secret.yml.j2
+++ b/roles/gitlab/templates/gitlab-runner-token-secret.yml.j2
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gitlab-group-runner-secret
-  namespace: gitlab-system
+  namespace: {{ ploigos_namespace }}
 type: Opaque
 stringData:
   runner-registration-token: {{ gitlab_runner_token }}

--- a/roles/gitlab/templates/gitlab-runner-token-secret.yml.j2
+++ b/roles/gitlab/templates/gitlab-runner-token-secret.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitlab-group-runner-secret
+  namespace: gitlab-system
+type: Opaque
+stringData:
+  runner-registration-token: {{ gitlab_runner_token }}

--- a/roles/gitlab/templates/gitlab-token-secret.yml.j2
+++ b/roles/gitlab/templates/gitlab-token-secret.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: gitlab-access-token
+    namespace: {{ ploigos_namespace }}
+data:
+    token: {{ gitlab_access_token | b64encode }}


### PR DESCRIPTION
### Features added

Add a GitLab role and playbook to configure a GitLab instance

### Notes
The roles assumed the user's kube context is pointed at a cluster running an instance of GitLab