### PR TITLE
WIP: Add npm repository to nexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This collection enables configuration of services to work with [Ploigos](https:/
 
 Supported components appear below. See the `playbooks` directory in this collection for usage notes and examples.
 
+## Prerequisites
+
+Some of the included roles use the devsecops-api command:
+```bash
+pip install devsecops-api
+```
+
+## Roles
+
 ### argocd
 This role configures an instance of ArgoCD for use with Ploigos. After supplying the relevant properties to the playbook, invoke it with:
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ploigos
 name: service_configs
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.8
+version: 1.0.9
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ploigos
 name: service_configs
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.7
+version: 1.0.8
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/nexus_artifacts/tasks/main.yml
+++ b/roles/nexus_artifacts/tasks/main.yml
@@ -5,8 +5,8 @@
     status_code: [200,401]
   register: _nexus_endpoint
   until: '_nexus_endpoint.status in [200,401]'
-  retries: 30
-  delay: 5
+  retries: 1
+  delay: 1
 
 - name: Create ploigos Service Account
   shell: >
@@ -15,6 +15,9 @@
     --login-username {{ nexus_username }} --login-password {{ nexus_password }}
     --usernames "{{ ploigos_service_account.username }}"
     --passwords "{{ ploigos_service_account.password }}"
+  register: created_nexus_service_account
+  changed_when: created_nexus_service_account.stdout_lines|to_json|from_json|json_query("[?ends_with(@, ` added`)]")|length > 0
+  failed_when: created_nexus_service_account.stdout_lines|to_json|from_json|json_query("[?ends_with(@, ` failed`)]")|length > 0 or created_nexus_service_account.rc != 0
 
 - name: Change the settings on the maven-releases repo to allow artifacts to be overwritten
   shell: >-
@@ -44,3 +47,41 @@
   - container-image-signatures
   - result-artifacts-archive
   - workflow-evidence
+
+- name: Add npm repository
+  shell: >-
+    devsecops-api nexus add-npm-repository
+    {{ nexus_url }}
+    --login-username '{{ nexus_username }}' --login-password '{{ nexus_password }}'
+    --repository-names 'npm-internal'
+  register: updated_npm_repo
+  # https://github.com/ansible/ansible/issues/27299
+  # to_json|from_json| is a terrible hack but here we are
+  changed_when: updated_npm_repo.stdout_lines|to_json|from_json|json_query("[?ends_with(@, ` added`)]")|length > 0
+  failed_when: updated_npm_repo.stdout_lines|to_json|from_json|json_query("[?ends_with(@, ` failed`)]")|length > 0 or updated_npm_repo.rc != 0
+
+- name: Create npm-publisher role
+  shell: >-
+    devsecops-api nexus add-role
+    {{ nexus_url }}
+    --login-username '{{ nexus_username }}' --login-password '{{ nexus_password }}'
+    --role-id 'npm-publisher'
+    --privileges 'nx-repository-view-npm-*-read,nx-repository-view-npm-*-edit,nx-repository-view-npm-*-browse'
+  register: added_npm_publisher_role
+  # https://github.com/ansible/ansible/issues/27299
+  # to_json|from_json| is a terrible hack but here we are
+  changed_when: added_npm_publisher_role.stdout_lines|to_json|from_json|json_query("[?ends_with(@, ` added`)]")|length > 0
+  failed_when: added_npm_publisher_role.stdout_lines|to_json|from_json|json_query("[?ends_with(@, ` failed`)]")|length > 0 or added_npm_publisher_role.rc != 0
+
+- name: Grant npm-publisher role to user
+  shell: >-
+    devsecops-api nexus grant-role-to-user
+    {{ nexus_url }}
+    --login-username '{{ nexus_username }}' --login-password '{{ nexus_password }}'
+    --role-id 'npm-publisher'
+    --user-name '{{ ploigos_service_account.username }}'
+  register: granted_npm_publisher_role
+  # https://github.com/ansible/ansible/issues/27299
+  # to_json|from_json| is a terrible hack but here we are
+  changed_when: granted_npm_publisher_role.stdout_lines|to_json|from_json|json_query("[?ends_with(@, ` added`)]")|length > 0
+  failed_when: granted_npm_publisher_role.stdout_lines|to_json|from_json|json_query("[?ends_with(@, ` failed`)]")|length > 0 or granted_npm_publisher_role.rc != 0

--- a/roles/nexus_artifacts/tasks/main.yml
+++ b/roles/nexus_artifacts/tasks/main.yml
@@ -5,8 +5,8 @@
     status_code: [200,401]
   register: _nexus_endpoint
   until: '_nexus_endpoint.status in [200,401]'
-  retries: 1
-  delay: 1
+  retries: 30
+  delay: 5
 
 - name: Create ploigos Service Account
   shell: >


### PR DESCRIPTION
**What?**
Updated the nexus_artifacts role to add an npm repository

**Why?**
We're adding npm support to ploigos-step-runner

**Dependencies**
There's a PR with required enhancements to devsecops-api-collection - 

**How To Test It:**
```
podman run -d -p 8081:8081 --name nexus docker.io/sonatype/nexus3
sleep 60
export NEXUS_ADMIN_PASSWORD=$(podman exec nexus cat /nexus-data/admin.password) && echo ${NEXUS_ADMIN_PASSWORD}
ansible-playbook --extra-vars "{\"nexus_url\": \"http://localhost:8081\", \"nexus_username\": \"admin\", \"nexus_password\": \"${NEXUS_ADMIN_PASSWORD}\", ploigos_service_account: {\"username\": \"sa-ploigos-ref-apps\", \"password\": \"password\"} }" ./playbooks/nexus_artifacts.yml
```

**Note:** currently the nexus roles give the service-account nx-admin. I'm also giving an npm-specific role anyway because a) we should stop giving it admin someday, and b) I want to use this in the rht-set environment where the service account does not have admin.